### PR TITLE
Modified approach for time init additions

### DIFF
--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -36,15 +36,29 @@ class TestBasic():
         assert np.allclose(t.cxcsec, np.array([3.15360643e+07,
                                                3.78691266e+08]))
 
-    def test_copy(self):
+    def test_copy_time(self):
         """Test copying the values of a Time object by passing it into the
         Time initializer.
         """
         t = Time(2455197.5, format='jd', scale='utc')
-        t2 = Time(t)
 
+        t2 = Time(t, copy=False)
         assert t.jd - t2.jd == 0
         assert (t - t2).jd == 0
+        assert t._time.jd1 is t2._time.jd1
+        assert t._time.jd2 is t2._time.jd2
+
+        t2 = Time(t, copy=True)
+        assert t.jd - t2.jd == 0
+        assert (t - t2).jd == 0
+        assert t._time.jd1 is not t2._time.jd1
+        assert t._time.jd2 is not t2._time.jd2
+
+        # Include initializers
+        t2 = Time(t, format='iso', scale='tai', precision=1)
+        assert t2.val == '2010-01-01 00:00:34.0'
+        t2 = Time(t, format='iso', scale='tai', out_subfmt='date')
+        assert t2.val == '2010-01-01'
 
     def test_properties(self):
         """Use properties to convert scales and formats.  Note that the UT1 to

--- a/astropy/time/tests/test_delta.py
+++ b/astropy/time/tests/test_delta.py
@@ -50,3 +50,25 @@ class TestTimeDelta():
         dt = self.t2 - self.t
         t2 = dt + self.t
         assert t2.iso == self.t2.iso
+
+    def test_copy_timedelta(self):
+        """Test copying the values of a TimeDelta object by passing it into the
+        Time initializer.
+        """
+        t = Time(2455197.5, format='jd', scale='utc')
+        t2 = Time(2455198.5, format='jd', scale='utc')
+        dt = t2 - t
+
+        dt2 = TimeDelta(dt, copy=False)
+        assert dt.jd == dt2.jd
+        assert dt._time.jd1 is dt2._time.jd1
+        assert dt._time.jd2 is dt2._time.jd2
+
+        dt2 = TimeDelta(dt, copy=True)
+        assert dt.jd == dt2.jd
+        assert dt._time.jd1 is not dt2._time.jd1
+        assert dt._time.jd2 is not dt2._time.jd2
+
+        # Include initializers
+        dt2 = TimeDelta(dt, format='sec')
+        assert np.allclose(dt2.val, 86400.0)


### PR DESCRIPTION
Good idea to allow for initializing the Time object with an existing Time object.  

There is an existing method `Time.replicate(self, format, copy)` that makes a reference copy or deep copy (copy=True) of a Time object.  I used this method within a new `Time.__new__` method to take care of the copying bit when `val` is a `Time` object.  The main benefit of this approach is that all the other `Time` initialization keywords will now function as expected, i.e. `format`, `scale`, `precision`, and so on.  

Also added code to do the same in `TimeDelta`.
