### PR TITLE
Make array * unit return a Quantity containing an array, not an array of quantity/allow-arrays-fix

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -51,6 +51,10 @@ class UnitBase(object):
     _registry = []
     _namespace = {}
 
+    # Make sure that __rmul__ of units gets called over the __mul__ of Numpy
+    # arrays to avoid element-wise multiplication.
+    __array_priority__ = 1000
+
     def __deepcopy__(self, memo):
         # This may look odd, but the units conversion will be very
         # broken after deep-copying if we don't guarantee that a given

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -314,8 +314,7 @@ def test_arrays():
         assert_array_equal((qsec - 2).value, (np.arange(10) + 2))
 
     #should create by unit multiplication, too
-    #qsec2 = np.arange(10) * u.second  # TODO: replace the next line with this once we figure out how to make numpy * unit work right
-    qsec2 = u.Quantity(np.arange(10), u.second)
+    qsec2 = np.arange(10) * u.second
     qsec3 = u.second * np.arange(10)
 
     assert np.all(qsec == qsec2)


### PR DESCRIPTION
I found this fix by digging around in this thread: http://comments.gmane.org/gmane.comp.python.scientific.devel/12488
