### PR TITLE
Coordinates ape5 rep tests

### DIFF
--- a/astropy/coordinates/__init__.py
+++ b/astropy/coordinates/__init__.py
@@ -17,5 +17,6 @@ from .builtin_systems import *
 from .name_resolve import *
 from .matching import *
 from .old_builtin_systems_names import *  # TODO: remove this in next version, along with module file
+from .representation import *
 
 __doc__ += builtin_systems._transform_graph_docs

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -359,7 +359,7 @@ class PhysicsSphericalRepresentation(BaseRepresentation):
         input for these classes is acceptable. This includes
         `~astropy.units.Quantity` instances, strings, and lists of strings.
 
-    distance : `~astropy.units.Quantity`
+    r : `~astropy.units.Quantity`
         The distance to the point(s). If the distance is a length, it is
         passed to the :class:`~astropy.coordinates.Distance` class, otherwise
         it is passed to the :class:`~astropy.units.Quantity` class.
@@ -368,27 +368,27 @@ class PhysicsSphericalRepresentation(BaseRepresentation):
         If True arrays will be copied rather than referenced.
     """
 
-    def __init__(self, phi, theta, distance, copy=True):
+    def __init__(self, phi, theta, r, copy=True):
 
         # Let the Longitude and Latitude classes deal with e.g. parsing
         phi = Angle(phi, copy=copy)
         theta = Angle(theta, copy=copy)
 
-        distance = u.Quantity(distance, copy=copy)
-        if distance.unit.physical_type == 'length':
-            distance = distance.view(Distance)
+        r = u.Quantity(r, copy=copy)
+        if r.unit.physical_type == 'length':
+            r = r.view(Distance)
 
         try:
-            phi, theta, distance = broadcast_quantity(phi, theta, distance, copy=copy)
+            phi, theta, r = broadcast_quantity(phi, theta, r, copy=copy)
         except ValueError:
-            raise ValueError("Input parameters phi, theta, and distance cannot be broadcast")
+            raise ValueError("Input parameters phi, theta, and r cannot be broadcast")
 
         self._phi = phi
         self._theta = theta
-        self._distance = distance
+        self._distance = r
 
     def __getitem__(self, view):
-        return self.__class__(self.phi[view], self.theta[view], self.distance[view])
+        return self.__class__(self.phi[view], self.theta[view], self.r[view])
 
     @property
     def phi(self):
@@ -405,7 +405,7 @@ class PhysicsSphericalRepresentation(BaseRepresentation):
         return self._theta
 
     @property
-    def distance(self):
+    def r(self):
         """
         The distance from the origin to the point(s).
         """
@@ -416,7 +416,7 @@ class PhysicsSphericalRepresentation(BaseRepresentation):
         if other_class is SphericalRepresentation:
             return SphericalRepresentation(lon=self.phi,
                                            lat=90 * u.deg - self.theta,
-                                           distance=self.distance)
+                                           distance=self.r)
         else:
             return super(PhysicsSphericalRepresentation, self).represent_as(other_class)
 

--- a/astropy/coordinates/tests/test_api_ape5.py
+++ b/astropy/coordinates/tests/test_api_ape5.py
@@ -109,9 +109,6 @@ def test_representations_api():
     # first dimension must be length-3 if a lone `Quantity` is passed in.
     c1 = coords.CartesianRepresentation(randn(3, 100) * u.kpc)
     assert c1.xyz.shape[0] == 3
-    #assert c1.unit == u.kpc
-    # using `c1.xyz.unit` is the same as `c1.unit`, so it's not necessary to do this,
-    # but it illustrates that `xyz` is a full-fledged `Quantity`.
     assert c1.xyz.unit == u.kpc
     assert c1.x.shape[0] == 100
     assert c1.y.shape[0] == 100
@@ -123,8 +120,8 @@ def test_representations_api():
     xarr, yarr, zarr = randn(3, 100)
     c1 = coords.CartesianRepresentation(x=xarr*u.kpc, y=yarr*u.kpc, z=zarr*u.kpc)
     c2 = coords.CartesianRepresentation(x=xarr*u.kpc, y=yarr*u.kpc, z=zarr*u.pc)
-    #assert c2.unit == u.kpc
-    #assert c1.z.kpc / 1000 == c2.z.kpc
+    assert c2.x.unit == u.kpc
+    assert c1.z.kpc / 1000 == c2.z.kpc
 
     # CartesianRepresentation can also accept raw arrays and a `unit` keyword
     # instead of having units attached to each of `x`, `y`, and `z`. Note that this

--- a/astropy/coordinates/tests/test_api_ape5.py
+++ b/astropy/coordinates/tests/test_api_ape5.py
@@ -120,8 +120,8 @@ def test_representations_api():
     xarr, yarr, zarr = randn(3, 100)
     c1 = coords.CartesianRepresentation(x=xarr*u.kpc, y=yarr*u.kpc, z=zarr*u.kpc)
     c2 = coords.CartesianRepresentation(x=xarr*u.kpc, y=yarr*u.kpc, z=zarr*u.pc)
-    assert c2.x.unit == u.kpc
-    assert c1.z.kpc / 1000 == c2.z.kpc
+    assert c1.xyz.unit ==  c2.xyz.unit == u.kpc
+    npt.assert_allclose((c1.z / 1000) - c2.z, 0, atol=1e-10)
 
     # CartesianRepresentation can also accept raw arrays and a `unit` keyword
     # instead of having units attached to each of `x`, `y`, and `z`. Note that this


### PR DESCRIPTION
@astrofrog @Cadair - this fixes up the APE5 api test to work with the representations code.  It's mostly relatively minor things, but there's one issue as yet un-resolved: why doesn't:

```
cr = CartesianRepresentation(x=randn(100)*u.kpc,y=randn(100)*u.kpc,z=randn(100)*u.kpc)
cr.x.kpc
```

work?  Shouldn't `cr.x` be a `Distance` if it has length units?
