### PR TITLE
Trial implementation of __repr__ and __str__

### DIFF
--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -90,7 +90,7 @@ class BaseRepresentation(object):
         """
         allcomp = np.array([getattr(self, component).value
                             for component in self.components])
-        dtype = np.dtype([(component, np.float)
+        dtype = np.dtype([(str(component), np.float)
                           for component in self.components])
         return (np.rollaxis(allcomp, 0, len(allcomp.shape))
                 .copy().view(dtype).squeeze())


### PR DESCRIPTION
To have `repr` and `str` produce at least something, I combined the looks of `recarray` and `Quantity`, a bit like happens now for `EarthLocation`. The current implementation is far from fast & perfect, but suffices perhaps to show what it will look like (also, it seems impossible to raise an issue, so one has to do a PR...).

cc @eteq, @taldcroft, @astrofrog, @Cadair, @adrn

In action (note how the angle units get lost; bit of a pity, but not essential for now):

```
In [1]: from astropy.coordinates.representation import *

In [2]: import numpy as np; import astropy.units as u

In [3]: c = SphericalRepresentation(np.arange(0, 360, 90) * u.deg, np.arange(-90, 90, 45) * u.deg, np.arange(1,5)*u.pc)

In [4]: c
Out[4]: 
<SphericalRepresentation [(0.0, -90.0, 1.0),(90.0, -45.0, 2.0),
                          (180.0, 0.0, 3.0),(270.0, 45.0, 4.0)] (deg,deg,pc)>

In [5]: c.to_cartesian()
Out[5]: 
<CartesianRepresentation [(6.123233995736766e-17, 0.0, -1.0),
                          (8.659560562354934e-17, 1.4142135623730951, -1.414213562373095),
                          (-3.0, 3.6739403974420594e-16, 0.0),
                          (-5.19573633741296e-16, -2.8284271247461903, 2.82842712474619)] pc>

In [6]: c.represent_as(UnitSphericalRepresentation)
Out[6]: 
<UnitSphericalRepresentation [(0.0, -1.5707963267948966),
                              (1.5707963267948966, -0.7853981633974483),
                              (3.141592653589793, 0.0),
                              (4.71238898038469, 0.7853981633974483)] rad>

In [7]: c.represent_as(CylindricalRepresentation)
Out[7]: 
<CylindricalRepresentation [(6.123233995736766e-17, 0.0, -1.0),
                            (1.4142135623730951, 1.5707963267948966, -1.414213562373095),
                            (3.0, 3.141592653589793, 0.0),
                            (2.8284271247461903, -1.5707963267948968, 2.82842712474619)] (pc,rad,pc)>

n [8]: c.represent_as(PhysicsSphericalRepresentation)
Out[8]: 
<PhysicsSphericalRepresentation [(0.0, 180.0, 1.0),(90.0, 135.0, 2.0),
                                 (180.0, 90.0, 3.0),(270.0, 45.0, 4.0)] (deg,deg,pc)>

In [9]: print(c)
[(0.0, -90.0, 1.0) (90.0, -45.0, 2.0) (180.0, 0.0, 3.0) (270.0, 45.0, 4.0)] (deg,deg,pc)

In [10]: print(c.represent_as(UnitSphericalRepresentation))
[(0.0, -1.5707963267948966) (1.5707963267948966, -0.7853981633974483)
 (3.141592653589793, 0.0) (4.71238898038469, 0.7853981633974483)] rad
```
