### PR TITLE
Update APE5 accuracy tests

### DIFF
--- a/astropy/coordinates/tests/accuracy/test_fk4_no_e_fk4.py
+++ b/astropy/coordinates/tests/accuracy/test_fk4_no_e_fk4.py
@@ -9,7 +9,7 @@ import os
 import numpy as np
 
 from .... import units as u
-from ... import FK4NoETerms, FK4
+from ...builtin_frames import FK4NoETerms, FK4
 from ....time import Time
 from ....table import Table
 from ...angle_utilities import angular_separation
@@ -26,9 +26,13 @@ def test_fk4_no_e_fk5():
 
     t = Table.read(os.path.join(ROOT, 'fk4_no_e_fk4.csv'), format='ascii')
 
-    # FK4 to FK5
-    c1 = FK4(t['ra_in'], t['dec_in'],
-             unit=(u.degree, u.degree),
+    # for i in range(len(t)):
+
+    #     # Extract row
+    #     r = t[i]
+
+    # FK4 to FK4NoETerms
+    c1 = FK4(ra=t['ra_in']*u.deg, dec=t['dec_in']*u.deg,
              obstime=Time(t['obstime'], scale='utc'))
     c2 = c1.transform_to(FK4NoETerms)
 
@@ -38,14 +42,14 @@ def test_fk4_no_e_fk5():
 
     assert np.all(np.degrees(diff) * 3600. < TOLERANCE)
 
-    # FK5 to FK4
-    c1 = FK4NoETerms(t['ra_in'], t['dec_in'],
-                     unit=(u.degree, u.degree),
+    # FK4NoETerms to FK4
+    c1 = FK4NoETerms(ra=t['ra_in']*u.deg, dec=t['dec_in']*u.deg,
                      obstime=Time(t['obstime'], scale='utc'))
     c2 = c1.transform_to(FK4)
 
     # Find difference
     diff = angular_separation(c2.ra.radian, c2.dec.radian,
-                              np.radians(t['ra_fk4']), np.radians(t['dec_fk4']))
+                              np.radians(t['ra_fk4']),
+                              np.radians(t['dec_fk4']))
 
     assert np.all(np.degrees(diff) * 3600. < TOLERANCE)

--- a/astropy/coordinates/tests/accuracy/test_fk4_no_e_fk5.py
+++ b/astropy/coordinates/tests/accuracy/test_fk4_no_e_fk5.py
@@ -5,7 +5,7 @@ import os
 import numpy as np
 
 from .... import units as u
-from ... import FK4NoETerms, FK5
+from ...builtin_frames import FK4NoETerms, FK5
 from ....time import Time
 from ....table import Table
 from ...angle_utilities import angular_separation
@@ -24,28 +24,28 @@ def test_fk4_no_e_fk5():
         # Extract row
         r = t[i]
 
-        # FK4 to FK5
-        c1 = FK4NoETerms(r['ra_in'], r['dec_in'],
-                                   unit=(u.degree, u.degree),
-                                   obstime=Time(r['obstime'], scale='utc'),
-                                   equinox=Time(r['equinox_fk4'], scale='utc'))
-        c2 = c1.transform_to(FK5).precess_to(Time(r['equinox_fk5'], scale='utc'))
+        # FK4NoETerms to FK5
+        c1 = FK4NoETerms(ra=r['ra_in']*u.deg, dec=r['dec_in']*u.deg,
+                         obstime=Time(r['obstime'], scale='utc'),
+                         equinox=Time(r['equinox_fk4'], scale='utc'))
+        c2 = c1.transform_to(FK5(equinox=Time(r['equinox_fk5'], scale='utc')))
 
         # Find difference
         diff = angular_separation(c2.ra.radian, c2.dec.radian,
-                                    np.radians(r['ra_fk5']), np.radians(r['dec_fk5']))
+                                  np.radians(r['ra_fk5']),
+                                  np.radians(r['dec_fk5']))
 
         assert np.degrees(diff) * 3600. < TOLERANCE
 
-        # FK5 to FK4
-        c1 = FK5(r['ra_in'], r['dec_in'],
-                            unit=(u.degree, u.degree),
-                            obstime=Time(r['obstime'], scale='utc'),
-                            equinox=Time(r['equinox_fk5'], scale='utc'))
-        c2 = c1.transform_to(FK4NoETerms).precess_to(Time(r['equinox_fk4'], scale='utc'))
+        # FK5 to FK4NoETerms
+        c1 = FK5(ra=r['ra_in']*u.deg, dec=r['dec_in']*u.deg,
+                 obstime=Time(r['obstime'], scale='utc'),
+                 equinox=Time(r['equinox_fk5'], scale='utc'))
+        c2 = c1.transform_to(FK4NoETerms(equinox=Time(r['equinox_fk4'], scale='utc')))
 
         # Find difference
         diff = angular_separation(c2.ra.radian, c2.dec.radian,
-                                    np.radians(r['ra_fk4']), np.radians(r['dec_fk4']))
+                                  np.radians(r['ra_fk4']),
+                                  np.radians(r['dec_fk4']))
 
         assert np.degrees(diff) * 3600. < TOLERANCE

--- a/astropy/coordinates/tests/accuracy/test_galactic_fk4.py
+++ b/astropy/coordinates/tests/accuracy/test_galactic_fk4.py
@@ -8,7 +8,7 @@ import os
 import numpy as np
 
 from .... import units as u
-from ... import Galactic, FK4
+from ...builtin_frames import Galactic, FK4
 from ....time import Time
 from ....table import Table
 from ...angle_utilities import angular_separation
@@ -27,27 +27,26 @@ def test_galactic_fk4():
         # Extract row
         r = t[i]
 
-        # FK4 to FK5
-        c1 = Galactic(r['lon_in'], r['lat_in'],
-                                 unit=(u.degree, u.degree),
-                                 obstime=Time(r['obstime'], scale='utc'))
-        c2 = c1.transform_to(FK4).precess_to(Time(r['equinox_fk4'], scale='utc'))
+        # Galactic to FK4
+        c1 = Galactic(l=r['lon_in']*u.deg, b=r['lat_in']*u.deg)
+        c2 = c1.transform_to(FK4(equinox=Time(r['equinox_fk4'], scale='utc')))
 
         # Find difference
         diff = angular_separation(c2.ra.radian, c2.dec.radian,
-                                    np.radians(r['ra_fk4']), np.radians(r['dec_fk4']))
+                                  np.radians(r['ra_fk4']),
+                                  np.radians(r['dec_fk4']))
 
         assert np.degrees(diff) * 3600. < TOLERANCE
 
-        # FK5 to FK4
-        c1 = FK4(r['lon_in'], r['lat_in'],
-                            unit=(u.degree, u.degree),
-                            obstime=Time(r['obstime'], scale='utc'),
-                            equinox=Time(r['equinox_fk4'], scale='utc'))
+        # FK4 to Galactic
+        c1 = FK4(ra=r['lon_in']*u.deg, dec=r['lat_in']*u.deg,
+                 obstime=Time(r['obstime'], scale='utc'),
+                 equinox=Time(r['equinox_fk4'], scale='utc'))
         c2 = c1.transform_to(Galactic)
 
         # Find difference
         diff = angular_separation(c2.l.radian, c2.b.radian,
-                                    np.radians(r['lon_gal']), np.radians(r['lat_gal']))
+                                  np.radians(r['lon_gal']),
+                                  np.radians(r['lat_gal']))
 
         assert np.degrees(diff) * 3600. < TOLERANCE

--- a/astropy/coordinates/tests/accuracy/test_icrs_fk5.py
+++ b/astropy/coordinates/tests/accuracy/test_icrs_fk5.py
@@ -7,7 +7,7 @@ import os
 import numpy as np
 
 from .... import units as u
-from ... import ICRS, FK5
+from ...builtin_frames import ICRS, FK5
 from ....time import Time
 from ....table import Table
 from ...angle_utilities import angular_separation
@@ -26,27 +26,25 @@ def test_icrs_no_e_fk5():
         # Extract row
         r = t[i]
 
-        # FK4 to FK5
-        c1 = ICRS(r['ra_in'], r['dec_in'],
-                             unit=(u.degree, u.degree),
-                             obstime=Time(r['obstime'], scale='utc'))
-        c2 = c1.transform_to(FK5).precess_to(Time(r['equinox_fk5'], scale='utc'))
+        # ICRS to FK5
+        c1 = ICRS(ra=r['ra_in']*u.deg, dec=r['dec_in']*u.deg)
+        c2 = c1.transform_to(FK5(equinox=Time(r['equinox_fk5'], scale='utc')))
 
         # Find difference
         diff = angular_separation(c2.ra.radian, c2.dec.radian,
-                                    np.radians(r['ra_fk5']), np.radians(r['dec_fk5']))
+                                  np.radians(r['ra_fk5']),
+                                  np.radians(r['dec_fk5']))
 
         assert np.degrees(diff) * 3600. < TOLERANCE
 
-        # FK5 to FK4
-        c1 = FK5(r['ra_in'], r['dec_in'],
-                            unit=(u.degree, u.degree),
-                            obstime=Time(r['obstime'], scale='utc'),
-                            equinox=Time(r['equinox_fk5'], scale='utc'))
+        # FK5 to ICRS
+        c1 = FK5(ra=r['ra_in']*u.deg, dec=r['dec_in']*u.deg,
+                 equinox=Time(r['equinox_fk5'], scale='utc'))
         c2 = c1.transform_to(ICRS)
 
         # Find difference
         diff = angular_separation(c2.ra.radian, c2.dec.radian,
-                                    np.radians(r['ra_icrs']), np.radians(r['dec_icrs']))
+                                  np.radians(r['ra_icrs']),
+                                  np.radians(r['dec_icrs']))
 
         assert np.degrees(diff) * 3600. < TOLERANCE


### PR DESCRIPTION
Here I've updated the accuracy tests to use the new frame classes. 

Note that there seems to be an accuracy issue with `test_fk4_no_e_fk5.py`, converting `FK4NoETerms` to `FK5`.
