### PR TITLE
Method to check if attributes were set explicitly

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -199,6 +199,11 @@ class BaseCoordinateFrame(object):
 
     @property
     def data(self):
+        """
+        The coordinate data for this object.  If this frame has no data, an
+        `AttributeError` will be raised.  Use `had_data` to check if data is
+        present on this frame object.
+        """
         if self._data is None:
             raise AttributeError('The frame object "{0}" does not have '
                                  'associated data'.format(repr(self)))
@@ -206,11 +211,15 @@ class BaseCoordinateFrame(object):
 
     @property
     def has_data(self):
+        """
+        True if this frame has `data`, False otherwise.
+        """
         return self._data is not None
 
     def realize_frame(self, representation):
         """
-        Generates a new frame *with data* from a frame without data.
+        Generates a new frame *with new data* from another frame (which may or
+        may not have data).
 
         Parameters
         ----------
@@ -228,6 +237,33 @@ class BaseCoordinateFrame(object):
         return self.__class__(representation, **frattrs)
 
     def represent_as(self, new_representation):
+        """
+        Generate and return a new representation of this frame's `data`.
+
+        Parameters
+        ----------
+        new_representation : subclass of BaseRepresentation
+            The type of representation to generate, as a *class* (not an
+            instance).
+
+        Returns
+        -------
+        newrep : whatever `new_representation` is
+            A new representation object of this frame's `data`.
+
+        Raises
+        ------
+        AttributeError
+            If this object had no `data`
+
+        Examples
+        --------
+        >>> from astropy import units as u
+        >>> from astropy.coordinates import ICRS, CartesianRepresentation
+        >>> coord = ICRS(0*u.deg, 0*u.deg)
+        >>> coord.represent_as(CartesianRepresentation)
+        <CartesianRepresentation x=1.0 , y=0.0 , z=0.0 >
+        """
         cached_repr = self._rep_cache.get(new_representation.__name__, None)
         if not cached_repr:
             rep = self.data.represent_as(new_representation)
@@ -345,10 +381,9 @@ class BaseCoordinateFrame(object):
             if self.preferred_representation:
                 if (self.preferred_representation == SphericalRepresentation and
                     isinstance(self.data, UnitSphericalRepresentation)):
-                    data = self.data.represent_as(UnitSphericalRepresentation)
+                    data = self.represent_as(UnitSphericalRepresentation)
                 else:
-                    data = self.data.represent_as(self.preferred_representation)
-
+                    data = self.represent_as(self.preferred_representation)
                 # if necessary, make a new representation with preferred units
                 if self.preferred_attr_units:
                     # first figure out how to map *representation* attribute

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -17,6 +17,8 @@ import numpy as np
 from ..extern import six
 from .. import units as u
 from .transformations import TransformGraph
+from .representation import BaseRepresentation, CartesianRepresentation, \
+                            SphericalRepresentation, UnitSphericalRepresentation
 
 __all__ = ['BaseCoordinateFrame', 'frame_transform_graph', 'GenericFrame']
 
@@ -132,14 +134,9 @@ class BaseCoordinateFrame(object):
     time_attr_names = ('equinox', 'obstime')  # Attributes that must be Time objects
 
     def __init__(self, *args, **kwargs):
-        from .representation import SphericalRepresentation, \
-                                    UnitSphericalRepresentation, \
-                                    BaseRepresentation
-
         representation = None  # if not set below, this is a frame with no data
 
         for fnm, fdefault in self.frame_attr_names.items():
-
             # read-only properties for these attributes are made in the
             # metaclass  so we set the 'real' attrbiutes as the name prefaced
             # with an underscore
@@ -318,9 +315,6 @@ class BaseCoordinateFrame(object):
             return True
 
     def __repr__(self):
-        from .representation import SphericalRepresentation, \
-                                    UnitSphericalRepresentation
-
         frameattrs = ', '.join([attrnm + '=' + str(getattr(self, attrnm))
                                 for attrnm in self.frame_attr_names])
 
@@ -411,7 +405,6 @@ class BaseCoordinateFrame(object):
         .. [1] http://en.wikipedia.org/wiki/Great-circle_distance
 
         """
-        from .representation import UnitSphericalRepresentation
         from .angle_utilities import angular_separation
         from .angles import Angle
 
@@ -443,7 +436,6 @@ class BaseCoordinateFrame(object):
         ValueError
             If this or the other coordinate do not have distances.
         """
-        from .representation import UnitSphericalRepresentation
         from .distances import Distance
 
         if self.data.__class__ == UnitSphericalRepresentation:
@@ -471,8 +463,6 @@ class BaseCoordinateFrame(object):
         """
         # TODO: if representations are updated to use a full transform graph,
         #       the representation aliases should not be hard-coded like this
-        from .representation import CartesianRepresentation
-
         return self.represent_as(CartesianRepresentation)
 
     @property
@@ -482,8 +472,6 @@ class BaseCoordinateFrame(object):
         """
         # TODO: if representations are updated to use a full transform graph,
         #       the representation aliases should not be hard-coded like this
-        from .representation import SphericalRepresentation
-
         return self.represent_as(SphericalRepresentation)
 
 

--- a/astropy/coordinates/builtin_frames.py
+++ b/astropy/coordinates/builtin_frames.py
@@ -187,9 +187,6 @@ class FK4(BaseCoordinateFrame):
             return self.equinox
         else:
             return self._obstime
-    @obstime.setter
-    def obstime(self, val):
-        self._obstime = val
 
 
 @frame_transform_graph.transform(FunctionTransform, FK4, FK4)
@@ -237,9 +234,6 @@ class FK4NoETerms(BaseCoordinateFrame):
             return self.equinox
         else:
             return self._obstime
-    @obstime.setter
-    def obstime(self, val):
-        self._obstime = val
 
     @staticmethod
     def _precession_matrix(oldequinox, newequinox):

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -9,7 +9,7 @@ from numpy.testing import assert_allclose
 
 from ... import units as u
 from ...tests.helper import pytest
-from .. import  representation
+from .. import representation
 
 def test_create_data_frames():
     from ..builtin_frames import ICRS
@@ -251,3 +251,28 @@ def test_time_inputs():
     with pytest.raises(ValueError) as err:
         c = FK4(1 * u.deg, 2 * u.deg, obstime=['J2000', 'J2001'])
     assert "must be a single (scalar) value" in str(err)
+
+
+def test_is_frame_attr_default():
+    """
+    Check that the `is_frame_attr_default` machinery works as expected
+    """
+    from ...time import Time
+    from ..builtin_frames import FK5
+
+    c1 = FK5(ra=1*u.deg, dec=1*u.deg)
+    c2 = FK5(ra=1*u.deg, dec=1*u.deg, equinox=FK5.frame_attr_names['equinox'])
+    c3 = FK5(ra=1*u.deg, dec=1*u.deg, equinox=Time('J2001.5'))
+
+    assert c1.equinox == c2.equinox
+    assert c1.equinox != c3.equinox
+
+    assert c1.is_frame_attr_default('equinox')
+    assert not c2.is_frame_attr_default('equinox')
+    assert not c3.is_frame_attr_default('equinox')
+
+    c4 = c1.realize_frame(representation.UnitSphericalRepresentation(3*u.deg, 4*u.deg))
+    c5 = c2.realize_frame(representation.UnitSphericalRepresentation(3*u.deg, 4*u.deg))
+
+    assert c4.is_frame_attr_default('equinox')
+    assert not c5.is_frame_attr_default('equinox')


### PR DESCRIPTION
As requested by @taldcroft in taldcroft/astropy#6, this adds a frame method and associated machinery that checks if a frame's attributes were set explicitly by the user, or provided as a default.

Note that initially I was thinking to have the `None` value internally mean default, but that doesn't work because in some cases the attribute might actually be `None` (e.g., for `obstime` it means "whatever equinox is")

There are a few other typos/minor fixes I added in the process of doing this that are also in this PR.
