### PR TITLE
added lookup_name to frames

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -254,7 +254,7 @@ class BaseCoordinateFrame(object):
     def data(self):
         """
         The coordinate data for this object.  If this frame has no data, an
-        `AttributeError` will be raised.  Use `had_data` to check if data is
+        `AttributeError` will be raised.  Use `has_data` to check if data is
         present on this frame object.
         """
         if self._data is None:
@@ -282,6 +282,41 @@ class BaseCoordinateFrame(object):
     @property
     def isscalar(self):
         return self.data.isscalar
+
+    @classmethod
+    def lookup_name(cls, transformgraph):
+        """
+        Determines the name used by this frame in the provided
+        transformation graph.
+
+        Parameters
+        ----------
+        transformgraph : `~astropy.coordinates.TransformGraph`
+            The graph to lookup the name of this object on.
+
+        Returns
+        -------
+        name : str
+            The string name of this frame in the ``transformgraph``
+            set of transformations.
+
+        Raises
+        ------
+        ValueError
+            If this frame is not in the ``transformgraph`` graph.
+
+        Notes
+        -----
+        The reason this is a method instead of a property is that
+        different frame classes can have different names on different
+        transform graphs.
+        """
+        for k, v in transformgraph._clsaliases.items():
+            if v == cls:
+                return k
+        else:
+            raise ValueError("Couldn't find the class {0} in the provided "
+                             "transform graph, so can't determine its name")
 
     def realize_frame(self, representation):
         """

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -127,6 +127,9 @@ class SkyCoord(object):
         """
         return self._coord
 
+    @property
+    def frame_name(self):
+        return self._coord.lookup_name(frame_transform_graph)
 
     def __len__(self):
         return len(self._coord)

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -129,7 +129,7 @@ class SkyCoord(object):
 
     @property
     def frame_name(self):
-        return self._coord.lookup_name(frame_transform_graph)
+        return frame_transform_graph.lookup_name(self._coord)
 
     def __len__(self):
         return len(self._coord)

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -276,3 +276,11 @@ def test_is_frame_attr_default():
 
     assert c4.is_frame_attr_default('equinox')
     assert not c5.is_frame_attr_default('equinox')
+
+
+def test_lookup_name():
+    from ..builtin_frames import ICRS, FK5, frame_transform_graph
+
+    i = ICRS(ra=0*u.deg, dec=1*u.deg)
+    assert i.lookup_name(frame_transform_graph) == 'icrs'
+    assert FK5.lookup_name(frame_transform_graph) == 'fk5'


### PR DESCRIPTION
This adds a way for frame objects to figure out what their aliases are in a particular transform graph.  This was triggered by discussion in astropy/astropy#2422 with @taldcroft about how to make frames visible on `SkyCoord`.

The plan there was to just add `name` property to the frame classes.  The problem with that is this: these names (or perhaps "aliases") are _not_ unique to the class.  They instead are unique to the _transform graph_.  The idea is that this might allow similar frames to be used with different names in different contexts (e.g., you might want FK5 to just be 'fk5' in the current coordinates framework, but in gWCS, it might be better named something like 'fk5_spatial_coordinate' or whatever).  But that's impossible if you force the "short" name to live on the class itself.  

So this PR is a modification of that idea to instead add a `lookup_name` class method.  For `SkyCoord`, this just means where originally we had been thinking `self.frame.name`, after this PR it could be `self.frame.lookup_name(frame_transform_graph)`.  Let me know what you think, @taldcroft.
