### PR TITLE
Make SkyCoord.frame be the internal frame object

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -401,10 +401,10 @@ class BaseCoordinateFrame(object):
             #means use the defaults for this class
             new_frame = new_frame()
 
-        if hasattr(new_frame, '_coord'):
+        if hasattr(new_frame, '_sky_coord_frame'):
             # Input new_frame is not a frame instance or class and is most
             # likely a SkyCoord object.
-            new_frame = new_frame._coord
+            new_frame = new_frame._sky_coord_frame
 
         trans = frame_transform_graph.get_transform(self.__class__,
                                                     new_frame.__class__)

--- a/astropy/coordinates/name_resolve.py
+++ b/astropy/coordinates/name_resolve.py
@@ -159,6 +159,6 @@ def get_icrs_coordinates(name):
 
         raise NameResolveError(err)
 
-    # use SkyCoord for its string-parsing capabilities
+    # Return SkyCoord object
     sc = SkyCoord(ra=ra, dec=dec, unit=(u.degree, u.degree), frame='icrs')
-    return sc.frame
+    return sc

--- a/astropy/coordinates/name_resolve.py
+++ b/astropy/coordinates/name_resolve.py
@@ -161,4 +161,4 @@ def get_icrs_coordinates(name):
 
     # use SkyCoord for its string-parsing capabilities
     sc = SkyCoord(ra=ra, dec=dec, unit=(u.degree, u.degree), frame='icrs')
-    return sc.coordobj
+    return sc.frame

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -530,27 +530,16 @@ class SkyCoord(object):
         """
         from .matching import match_coordinates_sky
 
-        if isinstance(catalogcoord, SkyCoord):
-            self_as_other_coord = self.transform_to(catalogcoord.frame).frame
-            other_coord = catalogcoord.frame
-            if hasattr(catalogcoord, '_kdtree_sky'):
-                other_coord._kdtree_sky = catalogcoord._kdtree_sky
-
-        elif isinstance(catalogcoord, BaseCoordinateFrame) and catalogcoord.has_data:
-            # It's a frame
-            self_as_other_coord = self.transform_to(catalogcoord).frame
-            other_coord = catalogcoord
+        if (isinstance(catalogcoord, (SkyCoord, BaseCoordinateFrame))
+                and catalogcoord.has_data):
+            self_in_catalog_frame = self.transform_to(catalogcoord)
         else:
             raise TypeError('Can only get separation to another SkyCoord or a '
                             'coordinate frame with data')
 
-        res = match_coordinates_sky(self_as_other_coord, other_coord,
+        res = match_coordinates_sky(self_in_catalog_frame, catalogcoord,
                                     nthneighbor=nthneighbor,
                                     storekdtree='_kdtree_sky')
-
-        # Update the cached KD-Tree - this is a no-op if its already cached
-        if catalogcoord is not other_coord:
-            catalogcoord._kdtree_sky = other_coord._kdtree_sky
         return res
 
     def match_to_catalog_3d(self, catalogcoord, nthneighbor=1):
@@ -601,27 +590,17 @@ class SkyCoord(object):
         """
         from .matching import match_coordinates_3d
 
-        if isinstance(catalogcoord, SkyCoord):
-            self_as_other_coord = self.transform_to(catalogcoord.frame).frame
-            other_coord = catalogcoord.frame
-            if hasattr(catalogcoord, '_kdtree_3d'):
-                other_coord._kdtree_3d = catalogcoord._kdtree_3d
-
-        elif isinstance(catalogcoord, BaseCoordinateFrame) and catalogcoord.has_data:
-            # It's a frame
-            self_as_other_coord = self.transform_to(catalogcoord).frame
-            other_coord = catalogcoord
+        if (isinstance(catalogcoord, (SkyCoord, BaseCoordinateFrame))
+                and catalogcoord.has_data):
+            self_in_catalog_frame = self.transform_to(catalogcoord)
         else:
             raise TypeError('Can only get separation to another SkyCoord or a '
                             'coordinate frame with data')
 
-        res = match_coordinates_3d(self_as_other_coord, other_coord,
+        res = match_coordinates_3d(self_in_catalog_frame, catalogcoord,
                                    nthneighbor=nthneighbor,
                                    storekdtree='_kdtree_3d')
 
-        # Update the cached KD-Tree - this is a no-op if its already cached
-        if catalogcoord is not other_coord:
-            catalogcoord._kdtree_3d = other_coord._kdtree_3d
         return res
 
     # Name resolve

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1,7 +1,5 @@
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 
-import re
-from copy import deepcopy
 import collections
 
 import numpy as np
@@ -14,17 +12,19 @@ from .. import units as u
 
 from .angles import Latitude, Longitude
 from .baseframe import BaseCoordinateFrame, frame_transform_graph, GenericFrame
-from .representation import BaseRepresentation, SphericalRepresentation, \
-                            UnitSphericalRepresentation
+from .representation import (BaseRepresentation, SphericalRepresentation,
+                             UnitSphericalRepresentation)
 
 __all__ = ['SkyCoord']
 
 # Define some convenience mappings.  These are used like module constants
 # but are actually dynamically evaluated.
 
+
 def FRAME_NAMES():
     """Dictionary mapping of frame name: frame class."""
     return frame_transform_graph.get_aliases()
+
 
 def FRAME_CLASSES():
     """Mapping from frame name to class"""
@@ -33,9 +33,11 @@ def FRAME_CLASSES():
     out[None] = out['icrs']
     return out
 
+
 def CLASS_TO_NAME_MAP():
     """Mapping from frame class to name"""
     return dict((cls, name) for name, cls in FRAME_CLASSES().items())
+
 
 def FRAME_ATTR_NAMES_SET():
     """Set of all possible frame-specific attributes"""
@@ -76,17 +78,15 @@ class SkyCoord(object):
     * Additional keywords will be interpreted as attributes of this `SkyCoord`,
       but will only be used by the containing coordinate if it is transformed.
 
-
     Parameters
     ----------
     frame : `~astropy.coordinates.BaseCoordinateFrame` class or string, optional
         The type of coordinate frame this `SkyCoord` should represent.  If a
-        string, it should be one of the aliases available in `astropy.coordinates.frame_transform_graph`,
-        typically an all-lower-case version of the system name.
+        string, it should be one of the aliases available in
+        `astropy.coordinates.frame_transform_graph`, typically an all-lower-case
+        version of the system name.
     others
         Other parameters depend on the type of frame - see above.
-
-
     """
 
     def __init__(self, *args, **kwargs):
@@ -399,7 +399,7 @@ class SkyCoord(object):
 
         return coord_string
 
-    #high-level convinience methods
+    # High-level convinience methods
     def separation(self, other):
         """
         Computes on-sky separation between this coordinate and another.
@@ -540,7 +540,7 @@ class SkyCoord(object):
                 other_coord._kdtree_sky = catalogcoord._kdtree_sky
 
         elif isinstance(catalogcoord, BaseCoordinateFrame) and catalogcoord.has_data:
-            # it's a frame
+            # It's a frame
             self_as_other_coord = self.transform_to(catalogcoord).coordobj
             other_coord = catalogcoord
         else:
@@ -551,7 +551,7 @@ class SkyCoord(object):
                                     nthneighbor=nthneighbor,
                                     storekdtree='_kdtree_sky')
 
-        #update the cached KD-Tree - this is a no-op if its already cached
+        # Update the cached KD-Tree - this is a no-op if its already cached
         if catalogcoord is not other_coord:
             catalogcoord._kdtree_sky = other_coord._kdtree_sky
         return res
@@ -611,7 +611,7 @@ class SkyCoord(object):
                 other_coord._kdtree_3d = catalogcoord._kdtree_3d
 
         elif isinstance(catalogcoord, BaseCoordinateFrame) and catalogcoord.has_data:
-            # it's a frame
+            # It's a frame
             self_as_other_coord = self.transform_to(catalogcoord).coordobj
             other_coord = catalogcoord
         else:

--- a/astropy/coordinates/tests/test_api_ape5.py
+++ b/astropy/coordinates/tests/test_api_ape5.py
@@ -344,7 +344,7 @@ def test_highlevel_api():
         sc = coords.SkyCoord(coords.FK5(equinox=J2001))  # raises ValueError
 
     # similarly, the low-level object can always be accessed
-    assert repr(sc.coordobj) == '<ICRS Coordinate: ra=120.0 deg, dec=5.0 deg>'
+    assert repr(sc.frame) == '<ICRS Coordinate: ra=120.0 deg, dec=5.0 deg>'
 
     # and  the string representation will be inherited from the low-level class.
     assert repr(sc) == '<SkyCoord (ICRS): ra=120.0 deg, dec=5.0 deg>'

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -53,6 +53,8 @@ for rt_frame0 in rt_frames:
                                             equinox0, equinox1,
                                             obstime0, obstime1])
 rt_args = 'frame0,frame1,equinox0,equinox1,obstime0,obstime1'
+
+
 @pytest.mark.parametrize(rt_args, rt_sets)
 def test_round_tripping(frame0, frame1, equinox0, equinox1, obstime0, obstime1):
     """
@@ -79,7 +81,7 @@ def test_round_tripping(frame0, frame1, equinox0, equinox1, obstime0, obstime1):
     # also, if any are None, fill in with defaults
     for attrnm in frame0.frame_attr_names:
         if attrs0.get(attrnm, None) is None:
-            if attrnm=='obstime' and frame0.frame_attr_names[attrnm] is None:
+            if attrnm =='obstime' and frame0.frame_attr_names[attrnm] is None:
                 attrs0[attrnm] = attrs0['equinox']
             else:
                 attrs0[attrnm] = frame0.frame_attr_names[attrnm]
@@ -180,31 +182,31 @@ def test_frame_init():
     Different ways of providing the frame.
     """
     sc = SkyCoord(RA, DEC, frame='icrs')
-    assert sc.frame == 'icrs'
+    assert sc.frame_name == 'icrs'
 
     sc = SkyCoord(RA, DEC, frame=ICRS)
-    assert sc.frame == 'icrs'
+    assert sc.frame_name == 'icrs'
 
     sc = SkyCoord(RA, DEC, 'icrs')
-    assert sc.frame == 'icrs'
+    assert sc.frame_name == 'icrs'
 
     sc = SkyCoord(RA, DEC, ICRS)
-    assert sc.frame == 'icrs'
+    assert sc.frame_name == 'icrs'
 
     sc = SkyCoord('icrs', RA, DEC)
-    assert sc.frame == 'icrs'
+    assert sc.frame_name == 'icrs'
 
     sc = SkyCoord(ICRS, RA, DEC)
-    assert sc.frame == 'icrs'
+    assert sc.frame_name == 'icrs'
 
     sc = SkyCoord(sc)
-    assert sc.frame == 'icrs'
+    assert sc.frame_name == 'icrs'
 
     sc = SkyCoord(C_ICRS)
-    assert sc.frame == 'icrs'
+    assert sc.frame_name == 'icrs'
 
     SkyCoord(C_ICRS, frame='icrs')
-    assert sc.frame == 'icrs'
+    assert sc.frame_name == 'icrs'
 
     with pytest.raises(ValueError) as err:
         SkyCoord(C_ICRS, frame='galactic')

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -81,7 +81,7 @@ def test_round_tripping(frame0, frame1, equinox0, equinox1, obstime0, obstime1):
     # also, if any are None, fill in with defaults
     for attrnm in frame0.frame_attr_names:
         if attrs0.get(attrnm, None) is None:
-            if attrnm =='obstime' and frame0.frame_attr_names[attrnm] is None:
+            if attrnm == 'obstime' and frame0.frame_attr_names[attrnm] is None:
                 attrs0[attrnm] = attrs0['equinox']
             else:
                 attrs0[attrnm] = frame0.frame_attr_names[attrnm]
@@ -97,8 +97,6 @@ def test_round_tripping(frame0, frame1, equinox0, equinox1, obstime0, obstime1):
         assert Time(sc.equinox) == Time(sc_rt.equinox)
     if obstime0:
         assert Time(sc.obstime) == Time(sc_rt.obstime)
-
-
 
 
 def test_coord_init_string():
@@ -169,7 +167,7 @@ def test_coord_init_representation():
         SkyCoord(coord, 'icrs', ra='1d')
     assert "conflicts with keyword argument 'ra'" in str(err)
 
-    coord = CartesianRepresentation(1*u.one, 2*u.one, 3*u.one)
+    coord = CartesianRepresentation(1 * u.one, 2 * u.one, 3 * u.one)
     sc = SkyCoord(coord, 'icrs')
     sc_cart = sc.represent_as(CartesianRepresentation)
     assert allclose(sc_cart.x, 1.0)
@@ -320,31 +318,31 @@ def test_to_string():
 
 
 def test_seps():
-    sc1 = SkyCoord('icrs', 0*u.deg, 1*u.deg)
-    sc2 = SkyCoord('icrs', 0*u.deg, 2*u.deg)
+    sc1 = SkyCoord('icrs', 0 * u.deg, 1 * u.deg)
+    sc2 = SkyCoord('icrs', 0 * u.deg, 2 * u.deg)
 
     sep = sc1.separation(sc2)
 
-    assert (sep - 1*u.deg)/u.deg < 1e-10
+    assert (sep - 1 * u.deg)/u.deg < 1e-10
 
     with pytest.raises(ValueError):
         sc1.separation_3d(sc2)
 
-    sc3 = SkyCoord('icrs', 1*u.deg, 1*u.deg, distance=1*u.kpc)
-    sc4 = SkyCoord('icrs', 1*u.deg, 1*u.deg, distance=2*u.kpc)
+    sc3 = SkyCoord('icrs', 1 * u.deg, 1 * u.deg, distance=1 * u.kpc)
+    sc4 = SkyCoord('icrs', 1 * u.deg, 1 * u.deg, distance=2 * u.kpc)
     sep3d = sc3.separation_3d(sc4)
 
-    assert sep3d == 1*u.kpc
+    assert sep3d == 1 * u.kpc
 
 
 def test_repr():
-    sc1 = SkyCoord('icrs', 0*u.deg, 1*u.deg)
-    sc2 = SkyCoord('icrs', 1*u.deg, 1*u.deg, distance=1*u.kpc)
+    sc1 = SkyCoord('icrs', 0 * u.deg, 1 * u.deg)
+    sc2 = SkyCoord('icrs', 1 * u.deg, 1 * u.deg, distance=1 * u.kpc)
 
     assert repr(sc1) == '<SkyCoord (ICRS): ra=0.0 deg, dec=1.0 deg>'
     assert repr(sc2) == '<SkyCoord (ICRS): ra=1.0 deg, dec=1.0 deg, distance=1.0 kpc>'
 
-    sc3 = SkyCoord('icrs', 0.1*u.deg, [1, 2.5]*u.deg)
+    sc3 = SkyCoord('icrs', 0.1 * u.deg, [1, 2.5] * u.deg)
     assert repr(sc3) == ('<SkyCoord (ICRS): (ra, dec) in deg\n'
                          '    [(0.10000000000002274, 1.0), (0.10000000000002274, 2.5)]>')
 
@@ -353,9 +351,9 @@ def test_ops():
     """
     Tests miscellaneous operations like `len`
     """
-    sc = SkyCoord('icrs', 0*u.deg, 1*u.deg)
-    sc_arr = SkyCoord('icrs', 0*u.deg, [1, 2]*u.deg)
-    sc_empty = SkyCoord('icrs', []*u.deg, []*u.deg)
+    sc = SkyCoord('icrs', 0 * u.deg, 1 * u.deg)
+    sc_arr = SkyCoord('icrs', 0 * u.deg, [1, 2] * u.deg)
+    sc_empty = SkyCoord('icrs', [] * u.deg, [] * u.deg)
 
     assert sc.isscalar
     assert not sc_arr.isscalar
@@ -369,5 +367,3 @@ def test_ops():
     assert bool(sc)
     assert bool(sc_arr)
     assert not bool(sc_empty)
-
-

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -225,7 +225,7 @@ def test_attr_inheritance():
     assert allclose(sc2.dec, sc.dec)
     assert allclose(sc2.distance, sc.distance)
 
-    sc2 = SkyCoord(sc._coord)  # Doesn't have equinox there so we get FK4 defaults
+    sc2 = SkyCoord(sc.frame)  # Doesn't have equinox there so we get FK4 defaults
     assert sc2.equinox != sc.equinox
     assert sc2.obstime != sc.obstime
     assert allclose(sc2.ra, sc.ra)
@@ -240,7 +240,7 @@ def test_attr_inheritance():
     assert allclose(sc2.dec, sc.dec)
     assert allclose(sc2.distance, sc.distance)
 
-    sc2 = SkyCoord(sc._coord)  # sc._coord has equinox, obstime
+    sc2 = SkyCoord(sc.frame)  # sc.frame has equinox, obstime
     assert sc2.equinox == sc.equinox
     assert sc2.obstime == sc.obstime
     assert allclose(sc2.ra, sc.ra)
@@ -257,8 +257,8 @@ def test_attr_conflicts():
     # OK if attrs both specified but with identical values
     SkyCoord(sc, equinox='J1999', obstime='J2001')
 
-    # OK because sc._coord doesn't have obstime
-    SkyCoord(sc._coord, equinox='J1999', obstime='J2100')
+    # OK because sc.frame doesn't have obstime
+    SkyCoord(sc.frame, equinox='J1999', obstime='J2100')
 
     # Not OK if attrs don't match
     with pytest.raises(ValueError) as err:
@@ -276,16 +276,16 @@ def test_attr_conflicts():
         SkyCoord(sc, equinox='J1999', obstime='J2002')
     assert "Coordinate attribute 'obstime'=" in str(err)
 
-    # Not OK because sc._coord has different attrs
+    # Not OK because sc.frame has different attrs
     with pytest.raises(ValueError) as err:
-        SkyCoord(sc._coord, equinox='J1999', obstime='J2002')
+        SkyCoord(sc.frame, equinox='J1999', obstime='J2002')
     assert "Coordinate attribute 'obstime'=" in str(err)
 
 
 def test_frame_attr_getattr():
     """
     When accessing frame attributes like equinox, the value should come
-    from self._coord when that object has the relevant attribute, otherwise
+    from self.frame when that object has the relevant attribute, otherwise
     from self.
     """
     sc = SkyCoord('icrs', 1, 2, unit='deg', equinox='J1999', obstime='J2001')
@@ -293,7 +293,7 @@ def test_frame_attr_getattr():
     assert sc.obstime == 'J2001'
 
     sc = SkyCoord('fk4', 1, 2, unit='deg', equinox='J1999', obstime='J2001')
-    assert sc.equinox == Time('J1999')  # Coming from the self._coord object
+    assert sc.equinox == Time('J1999')  # Coming from the self.frame object
     assert sc.obstime == Time('J2001')
 
     sc = SkyCoord('fk4', 1, 2, unit='deg', equinox='J1999')


### PR DESCRIPTION
This is failing one test in `test_api_ape5` (which actually points to a shortcoming in test coverage for `test_match.py` since it should be failing there as well).  The reason is that `SkyCoord` doesn't implement `__getitem__`.  I think this should be relatively straightforward but it's somewhat out of scope here.  The failure also just showed up on the last commit which hacks away half of the `SkyCoord.match_*` function code.  I think the code edits are right and all should work once `__getitem__` is doing the right thing.
