### PR TITLE
Coordinates ape5 1to1 framenames

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -72,6 +72,10 @@ class FrameMeta(type):
                     raise ValueError("A non-property exists that's *also* in frame_attr_names")
             clsdct[attrnm] = property(FrameMeta.frame_attr_factory(attrnm))
 
+        # now set the name as lower-case class name, if it isn't explicit
+        if '_name' not in clsdct:
+            clsdct['_name'] = name.lower()
+
         return super(FrameMeta, cls).__new__(cls, name, parents, clsdct)
 
     @staticmethod
@@ -282,37 +286,6 @@ class BaseCoordinateFrame(object):
     @property
     def isscalar(self):
         return self.data.isscalar
-
-    @classmethod
-    def lookup_names(cls, transformgraph):
-        """
-        Determines the name sused by this frame in the provided
-        transformation graph.
-
-        Parameters
-        ----------
-        transformgraph : `~astropy.coordinates.TransformGraph`
-            The graph to lookup the name of this object on.
-
-        Returns
-        -------
-        names : list of str
-            The string names of this frame in the ``transformgraph``
-            set of transformations.  If the class does not have a name,
-            this is an empty list
-
-        Notes
-        -----
-        The reason this is a method instead of a property is that
-        different frame classes can have different names on different
-        transform graphs.  They can also have multiple names on the
-        same graph (but the converse is not true).
-        """
-        names = []
-        for k, v in transformgraph._clsaliases.items():
-            if v == cls:
-                names.append(k)
-        return names
 
     def realize_frame(self, representation):
         """
@@ -648,6 +621,7 @@ class GenericFrame(BaseCoordinateFrame):
         A dictionary of attributes to be used as the frame attributes for this
         frame.
     """
+    _name = None  # it's not a "real" frame so it doesn't have a name
 
     def __init__(self, frame_attrs):
         super(GenericFrame, self).__init__(None)

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -73,8 +73,8 @@ class FrameMeta(type):
             clsdct[attrnm] = property(FrameMeta.frame_attr_factory(attrnm))
 
         # now set the name as lower-case class name, if it isn't explicit
-        if '_name' not in clsdct:
-            clsdct['_name'] = name.lower()
+        if 'name' not in clsdct:
+            clsdct['name'] = name.lower()
 
         return super(FrameMeta, cls).__new__(cls, name, parents, clsdct)
 
@@ -621,7 +621,7 @@ class GenericFrame(BaseCoordinateFrame):
         A dictionary of attributes to be used as the frame attributes for this
         frame.
     """
-    _name = None  # it's not a "real" frame so it doesn't have a name
+    name = None  # it's not a "real" frame so it doesn't have a name
 
     def __init__(self, frame_attrs):
         super(GenericFrame, self).__init__(None)

--- a/astropy/coordinates/builtin_frames.py
+++ b/astropy/coordinates/builtin_frames.py
@@ -32,7 +32,6 @@ _EQUINOX_J2000 = Time('J2000', scale='utc')
 _EQUINOX_B1950 = Time('B1950', scale='tai')
 
 
-@frame_transform_graph.add_coord_name
 class ICRS(BaseCoordinateFrame):
     """
     A coordinate or frame in the ICRS system.
@@ -85,7 +84,6 @@ class ICRS(BaseCoordinateFrame):
 ICRS._ICRS_TO_FK5_J2000_MAT = ICRS._icrs_to_fk5_matrix()
 
 
-@frame_transform_graph.add_coord_name
 class FK5(BaseCoordinateFrame):
     """
     A coordinate or frame in the FK5 system.
@@ -142,7 +140,6 @@ def fk5_to_fk5(fk5coord1, fk5frame2):
     return fk5coord1._precession_matrix(fk5coord1.equinox, fk5frame2.equinox)
 
 
-@frame_transform_graph.add_coord_name
 class FK4(BaseCoordinateFrame):
     """
     A coordinate or frame in the FK4 system.
@@ -190,7 +187,6 @@ def fk4_to_fk4(fk4coord1, fk4frame2):
     return fnoe_w_eqx2.transform_to(fk4frame2)
 
 
-@frame_transform_graph.add_coord_name
 class FK4NoETerms(BaseCoordinateFrame):
     """
     A coordinate or frame in the FK4 system, but with the E-terms of aberration
@@ -265,7 +261,6 @@ def fk4noe_to_fk4noe(fk4necoord1, fk4neframe2):
     return fk4necoord1._precession_matrix(fk4necoord1.equinox, fk4neframe2.equinox)
 
 
-@frame_transform_graph.add_coord_name
 class Galactic(BaseCoordinateFrame):
     """
     Galactic Coordinates.
@@ -300,7 +295,6 @@ class Galactic(BaseCoordinateFrame):
     _lon0_B1950 = Angle(123, u.degree)
 
 
-@frame_transform_graph.add_coord_name
 class AltAz(BaseCoordinateFrame):
     """
     A coordinate or frame in the AltAz system.

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -29,11 +29,6 @@ def FRAME_CLASSES():
     return out
 
 
-def CLASS_TO_NAME_MAP():
-    """Mapping from frame class to name"""
-    return dict((cls, name) for name, cls in FRAME_CLASSES().items())
-
-
 def FRAME_ATTR_NAMES_SET():
     """Set of all possible frame-specific attributes"""
     out = set()
@@ -677,7 +672,7 @@ def _get_frame_name(args, kwargs):
     if frame is not None:
         # Frame was provided as kwarg so validate and coerce into corresponding frame.
         frame_cls = _get_frame_class(frame)
-        frame_name = CLASS_TO_NAME_MAP()[frame_cls]
+        frame_name = frame_cls._name
     else:
         # Look for the frame in args
         for arg in args:
@@ -686,7 +681,7 @@ def _get_frame_name(args, kwargs):
             except ValueError:
                 pass
             else:
-                frame_name = CLASS_TO_NAME_MAP()[frame_cls]
+                frame_name = frame_cls._name
                 args.remove(arg)
                 break
         else:
@@ -699,7 +694,7 @@ def _get_frame_name(args, kwargs):
     for arg in args:
         coord_frame_name = None
         if isinstance(arg, BaseCoordinateFrame):
-            coord_frame_name = CLASS_TO_NAME_MAP()[arg.__class__]
+            coord_frame_name = arg.__class__._name
         elif isinstance(arg, SkyCoord):
             coord_frame_name = arg.frame_name
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -673,7 +673,7 @@ def _get_frame_name(args, kwargs):
     if frame is not None:
         # Frame was provided as kwarg so validate and coerce into corresponding frame.
         frame_cls = _get_frame_class(frame)
-        frame_name = frame_cls._name
+        frame_name = frame_cls.name
     else:
         # Look for the frame in args
         for arg in args:
@@ -682,7 +682,7 @@ def _get_frame_name(args, kwargs):
             except ValueError:
                 pass
             else:
-                frame_name = frame_cls._name
+                frame_name = frame_cls.name
                 args.remove(arg)
                 break
         else:
@@ -695,7 +695,7 @@ def _get_frame_name(args, kwargs):
     for arg in args:
         coord_frame_name = None
         if isinstance(arg, BaseCoordinateFrame):
-            coord_frame_name = arg.__class__._name
+            coord_frame_name = arg.__class__.name
         elif isinstance(arg, SkyCoord):
             coord_frame_name = arg.frame_name
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -24,7 +24,7 @@ __all__ = ['SkyCoord']
 def FRAME_CLASSES():
     """Mapping from frame name to class"""
     out = dict((name, frame_transform_graph.lookup_name(name))
-               for name in frame_transform_graph.get_aliases())
+               for name in frame_transform_graph.get_names())
     out[None] = out['icrs']
     return out
 
@@ -645,7 +645,7 @@ def _get_frame_class(frame):
     import inspect
 
     if isinstance(frame, six.string_types):
-        frame_names = frame_transform_graph.get_aliases()
+        frame_names = frame_transform_graph.get_names()
         if frame not in frame_names:
             raise ValueError('Coordinate frame {0} not in allowed values {1}'
                              .format(frame, sorted(frame_names)))

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -23,7 +23,7 @@ __all__ = ['SkyCoord']
 def FRAME_ATTR_NAMES_SET():
     """Set of all possible frame-specific attributes"""
     out = set()
-    for frame_cls in frame_transform_graph._cached_classes:
+    for frame_cls in frame_transform_graph.frame_set:
         for attr in frame_cls.frame_attr_names.keys():
             out.add(attr)
     return out

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -276,11 +276,3 @@ def test_is_frame_attr_default():
 
     assert c4.is_frame_attr_default('equinox')
     assert not c5.is_frame_attr_default('equinox')
-
-
-def test_lookup_name():
-    from ..builtin_frames import ICRS, FK5, frame_transform_graph
-
-    i = ICRS(ra=0*u.deg, dec=1*u.deg)
-    assert i.lookup_names(frame_transform_graph) == ['icrs']
-    assert FK5.lookup_names(frame_transform_graph) == ['fk5']

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -372,3 +372,22 @@ def test_ops():
     assert len(sc_arr[:1]) == 1
     with pytest.raises(TypeError):
         assert sc[0:]  # scalar, so it shouldn't be indexable
+
+
+def test_none_transform():
+    """
+    Ensure that transforming from a SkyCoord with no frame provided always fails
+    """
+    sc = SkyCoord(0 * u.deg, 1 * u.deg)
+    sc_arr = SkyCoord(0 * u.deg, [1, 2] * u.deg)
+
+    with pytest.raises(ValueError):
+        sc.transform_to(ICRS)
+    with pytest.raises(ValueError):
+        sc.transform_to('fk5')
+
+    with pytest.raises(ValueError):
+        sc_arr.transform_to(ICRS)
+    with pytest.raises(ValueError):
+        sc_arr.transform_to('fk5')
+

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -50,7 +50,7 @@ class TransformGraph(object):
         if self._cached_names_dct is None:
             self._cached_names_dct = dct = {}
             for c in self._cached_classes:
-                nm = getattr(c, '_name', None)
+                nm = getattr(c, 'name', None)
                 if nm is not None:
                     dct[nm] = c
 

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -37,19 +37,18 @@ __all__ = ['TransformGraph', 'CoordinateTransform', 'FunctionTransform',
 
 class TransformGraph(object):
     """
-    A graph representing the paths between coordinates.
+    A graph representing the paths between coordinate frames.
     """
 
     def __init__(self):
         self._graph = defaultdict(dict)
-
         self.invalidate_cache()  # generates cache entries
 
     @property
     def _cached_names(self):
         if self._cached_names_dct is None:
             self._cached_names_dct = dct = {}
-            for c in self._cached_classes:
+            for c in self.frame_set:
                 nm = getattr(c, 'name', None)
                 if nm is not None:
                     dct[nm] = c
@@ -57,15 +56,18 @@ class TransformGraph(object):
         return self._cached_names_dct
 
     @property
-    def _cached_classes(self):
-        if self._cached_classes_set is None:
-            self._cached_classes_set = cls_set = set()
+    def frame_set(self):
+        """
+        A `set` of all the frame classes present in this `TransformGraph`.
+        """
+        if self._cached_frame_set is None:
+            self._cached_frame_set = frm_set = set()
             for a in self._graph:
-                cls_set.add(a)
+                frm_set.add(a)
                 for b in self._graph[a]:
-                    cls_set.add(b)
+                    frm_set.add(b)
 
-        return self._cached_classes_set
+        return self._cached_frame_set.copy()
 
     def invalidate_cache(self):
         """
@@ -75,7 +77,7 @@ class TransformGraph(object):
         weights on transforms are modified inplace.
         """
         self._cached_names_dct = None
-        self._cached_classes_set = None
+        self._cached_frame_set = None
         self._shortestpaths = {}
         self._composite_cache = {}
 

--- a/docs/coordinates/sgr-example.py
+++ b/docs/coordinates/sgr-example.py
@@ -21,7 +21,6 @@ import astropy.units as u
 
 __all__ = ["SgrCoordinates"]
 
-@frame_transform_graph.add_coord_name
 class Sagittarius(coord.BaseCoordinateFrame):
     """
     A Heliocentric spherical coordinate system defined by the orbit

--- a/docs/coordinates/sgr-example.rst
+++ b/docs/coordinates/sgr-example.rst
@@ -26,7 +26,6 @@ The first step is to create a new class, which we'll call
     from astropy.coordinates import frame_transform_graph
     from astropy.coordinates.angles import rotation_matrix
 
-    @frame_transform_graph.add_coord_name
     class Sagittarius(coord.BaseCoordinateFrame):
         """
         A Heliocentric spherical coordinate system defined by the orbit


### PR DESCRIPTION
This PR addresses an issue that @taldcroft brought up in #28 : There's no really good reason for the feature that `TransformGraph` objects can have many names for each frame class.   In fact, that's probably more confusing than its worth.  So this changes things so that frames have a `name` class attribute that can be set explicitly, or if not, will be taken as `lower()` of the class name.  The functionality for adding names to `TransformGraph` is then removed in favor of using the names on the objects for the `TransformGraph` methods that deal with names.  If it does turn out in the future that aliases really are important in some context, they can always be added back in.

The presence of `name` attribute and the one-to-one assumption it allows then leads to various simplifications in `SkyCoord`... So you'll note this is @taldcroft's favorite kind of PR, with more code removed than added :wink:

Look good to you, @taldcroft ?
