### PR TITLE
Ensure scalar case of get_sun still works.

### DIFF
--- a/astropy/coordinates/funcs.py
+++ b/astropy/coordinates/funcs.py
@@ -161,16 +161,12 @@ def get_sun(time):
 
     dsun = np.sqrt(np.sum(earth_p**2, axis=-1))
     invlorentz = (1-np.sum(earth_v**2, axis=-1))**0.5
-    properdir = erfa.ab(earth_p/dsun.reshape(dsun.shape + (1,)), -earth_v, dsun, invlorentz)
+    properdir = erfa.ab(earth_p/dsun.reshape(dsun.shape + (1,)),
+                        -earth_v, dsun, invlorentz)
 
-    x = -dsun*properdir[..., 0] * u.AU
-    y = -dsun*properdir[..., 1] * u.AU
-    z = -dsun*properdir[..., 2] * u.AU
-
-    if time.isscalar:
-        cartrep = CartesianRepresentation(x=x[0], y=y[0], z=z[0])
-    else:
-        cartrep = CartesianRepresentation(x=x, y=y, z=z)
+    cartrep = CartesianRepresentation(x=-dsun*properdir[..., 0] * u.AU,
+                                      y=-dsun*properdir[..., 1] * u.AU,
+                                      z=-dsun*properdir[..., 2] * u.AU)
     return SkyCoord(cartrep, frame=GCRS(obstime=time))
 
 


### PR DESCRIPTION
@eteq - having led you up a blind alley, I thought the least I could do was to fix the remaining travis errors: turns out that with your change, there was no need to keep track of whether time was a scalar: the broadcasting now already ensures that in that case the output is scalar as well!
